### PR TITLE
limit street address to 50 chars

### DIFF
--- a/CRM/eWAYRecurring/PaymentToken.php
+++ b/CRM/eWAYRecurring/PaymentToken.php
@@ -121,7 +121,7 @@ class CRM_eWAYRecurring_PaymentToken {
       'LastName' => $billingDetails['last_name'],
       'Country' => $billingDetails['billing_country'],
       'Reference' => 'civi-' . $contact_id,
-      'Street1' => $billingDetails['billing_street_address'],
+      'Street1' => substr($billingDetails['billing_street_address'], 0, 50),
       'City' => $billingDetails['billing_city'],
       'State' => $billingDetails['billing_state_province'],
       'PostalCode' => $billingDetails['billing_postal_code'],


### PR DESCRIPTION
`Street1` value is limited to 50 char - https://eway.io/api-v3/#transaction-query. 

![image](https://user-images.githubusercontent.com/5929648/94800806-bb139300-0402-11eb-94de-b021c8062cfa.png)

If we have a billing street with more than the max length, we get -

![image](https://user-images.githubusercontent.com/5929648/94800503-4d676700-0402-11eb-8a78-14baff3c2404.png)

Possible fix? 

1. simply limit the addr to 50? This PR des that.
2. Show a warning on the system status page that some of the addresses are > 50 to let admin fix them.