### PR TITLE
info.xml: tag as stable

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -15,6 +15,7 @@
         <author>Agileware</author>
         <email>support@agileware.com.au</email>
     </maintainer>
+    <develStage>stable</develStage>
     <releaseDate>2020-12-14</releaseDate>
     <version>2.3.5</version>
     <compatibility>


### PR DESCRIPTION
Requirement for https://lab.civicrm.org/extensions/extension-review-requests/-/issues/4

Extension must tag a stable release.