### PR TITLE
Fix date display on safari browser

### DIFF
--- a/js/eway.js
+++ b/js/eway.js
@@ -28,7 +28,7 @@ CRM.eway.updateOptions = function (result) {
     }
     options.html = "";
     options.result.forEach(function (value) {
-        let expireDate = new Date(value.expiry_date);
+        let expireDate = new Date(value.expiry_date.replace(/\s/, 'T'));
         let month = expireDate.getMonth() + 1;
         if (month < 10) {
             month = '0' + month;


### PR DESCRIPTION
Expiry date is displayed as `NaN` since new Date with time string returns an Invalid date on safari browser.


![image](https://user-images.githubusercontent.com/5929648/111769662-7ce62f00-88cf-11eb-80e3-8b605be22aa3.png)

**After this patch-**

![image](https://user-images.githubusercontent.com/5929648/111769713-8a031e00-88cf-11eb-812e-1a2ff3d671f8.png)
