### PR TITLE
Set the invoice_id when using Contribution.completetransaction

### DIFF
--- a/eWAYRecurring.process.inc
+++ b/eWAYRecurring.process.inc
@@ -273,6 +273,20 @@ function process_recurring_payments($payment_processor, $paymentObject) {
 
       $new_contribution_record = reset($updated['values']);
 
+      // The invoice_id does not seem to be recorded by Contribution.completetransaction,
+      // so let's update it directly.
+      if ($api_action === 'completetransaction') {
+        $updated = civicrm_api3('Contribution', 'create', [
+          'id' => $updated['id'],
+          'financial_type_id' => $updated['financial_type_id'],
+          'receive_date' => $updated['receive_date'],
+          'total_amount' => $updated['total_amount'],
+          'contact_id' => $updated['contact_id'],
+          'invoice_id' => $invoice_id,
+        ]);
+        $new_contribution_record = reset($updated['values']);
+      }
+
       if (count($responseErrors)) {
         $note = new CRM_Core_BAO_Note();
 


### PR DESCRIPTION
When processing recurring payments, if it uses Contribution.completetransaction rather than Contribution.create, it appears that the invoice_id is left blank in the resulting payment record. It has been generated and passed along as a parameter, but that API call seems to ignore it.

This patch aims to address that with a Contribution.create call after the Contribution.completetransaction, but I don't know if this is the optimal solution.