### PR TITLE
Make sure expiry date is set to the last date of the month

### DIFF
--- a/CRM/eWAYRecurring/Utils.php
+++ b/CRM/eWAYRecurring/Utils.php
@@ -96,9 +96,8 @@ class CRM_eWAYRecurring_Utils {
         $apiResponse['deleted']++;
       }
     }
-    
+
     // Mark all pending transactions that have exceeded the retry limit as failed
-    
     $transactionsPendingMaxTries = civicrm_api3('EwayContributionTransactions', 'get', [
       'status' => self::STATUS_IN_QUEUE,
       'tries' => ['>=' => self::MAX_TRIES],
@@ -115,12 +114,12 @@ class CRM_eWAYRecurring_Utils {
           'id' => $contributionID,
           'contribution_status_id' => 'Failed',
         ]);
-        
+
       } catch (CiviCRM_API3_Exception $e) {
       // Contribution not found.
-      }        
+      }
     }
-    
+
     return $apiResponse;
 
   }
@@ -252,7 +251,7 @@ class CRM_eWAYRecurring_Utils {
 
       $expiryDate = new DateTime();
       $expiryDate->setDate($ccExpYear, $ccExpMonth, 1);
-      $expiryDate = $expiryDate->format("Y-m-d");
+      $expiryDate = $expiryDate->format("Y-m-t");
 
       $params = [
         'contact_id' => $recurringContribution['contact_id'],


### PR DESCRIPTION
We found most of the card's expiry date is not set to the last date of the month in `civicrm_payment_token` table. I assume it is due to this line that sets the expiry date to the exact value and does not convert it to the last date?

Does this make sense?