### PR TITLE
Set contribution invoice ID after Contribution.completetransaction

### DIFF
--- a/eWAYRecurring.process.inc
+++ b/eWAYRecurring.process.inc
@@ -273,6 +273,20 @@ function process_recurring_payments($payment_processor, $paymentObject) {
 
       $new_contribution_record = reset($updated['values']);
 
+      // The invoice_id does not seem to be recorded by
+      // Contribution.completetransaction, so let's update it directly.
+      if ($api_action === 'completetransaction') {
+        $updated = civicrm_api3('Contribution', 'create', [
+            'id' => $new_contribution_record['id'],
+            'financial_type_id' => $new_contribution_record['financial_type_id'],
+            'receive_date' => $new_contribution_record['receive_date'],
+            'total_amount' => $new_contribution_record['total_amount'],
+            'contact_id' => $new_contribution_record['contact_id'],
+            'invoice_id' => $invoice_id,
+        ]);
+        $new_contribution_record = reset($updated['values']);
+      }
+
       if (count($responseErrors)) {
         $note = new CRM_Core_BAO_Note();
 


### PR DESCRIPTION
This corrects the error in my previous pull request. It has not yet been tested, the first test of this code pathway should occur tonight on our test server.

The purpose of this change is to set the invoice_id for transactions which are completed by Contribution.completetransaction.

Edit: The previous pull request was [here](https://github.com/agileware/au.com.agileware.ewayrecurring/pull/16).