### PR TITLE
Ensure cid is available on adding cc via backend

### DIFF
--- a/js/eway.js
+++ b/js/eway.js
@@ -142,8 +142,12 @@ CRM.eway.addCreditCard = function () {
     if (typeof ppid === 'undefined') {
         ppid = CRM.eway.ppid;
     }
+    let cid = CRM.eway.contact_id;
+    if (!cid && CRM.vars.coreForm.contact_id) {
+      cid = CRM.vars.coreForm.contact_id;
+    }
     let url = CRM.url('civicrm/ewayrecurring/createtoken', {
-        'contact_id': CRM.eway.contact_id,
+        'contact_id': cid,
         'pp_id': ppid
     }, 'front');
     let data = CRM.$('form').serialize();


### PR DESCRIPTION
Cid is not always available on the backend form since it is only set with the cid value in present the request values https://github.com/agileware/au.com.agileware.ewayrecurring/blob/master/au_com_agileware_ewayrecurring.class.php#L100-L102. Not all forms have them? Eg submit cc payment.

To replicate- 

- Create a pay later contribution on a contact.
- Edit the contribution.
- Click on `Submit Credit Card` link 
 
![image](https://user-images.githubusercontent.com/5929648/127994181-afe50211-8b81-4468-9976-b50a8435ae32.png)

- Redirects to this URL - `civicrm/payment?action=add&reset=1&is_refund=0&id=101&mode=live`. No cid hence the button 

![image](https://user-images.githubusercontent.com/5929648/127994379-1243516f-56ff-4919-9c1a-c713a6aa888f.png)

- Click on the above button to add a card.

![image](https://user-images.githubusercontent.com/5929648/127994704-9d1a4d80-590a-410c-b3e3-a315eb739c55.png)

Fix here retrieves the cid from `coreForm` if it is not loaded by default. Seems this will always be available since it is set by core -

````
civicrm jitendra$ grep -irn "coreForm" CRM --color
CRM/Core/Form.php:2242:      CRM_Core_Resources::singleton()->addVars('coreForm', ['contact_id' => (int) $tempID]);
CRM/Core/Form.php:2249:      CRM_Core_Resources::singleton()->addVars('coreForm', ['contact_id' => (int) $tempID]);
CRM/Core/Form.php:2259:        CRM_Core_Resources::singleton()->addVars('coreForm', ['contact_id' => (int) $tempID]);
CRM/Core/Form.php:2260:        CRM_Core_Resources::singleton()->addVars('coreForm', ['checksum' => $userChecksum]);
CRM/Core/Form.php:2266:      CRM_Core_Resources::singleton()->addVars('coreForm', ['contact_id' => (int) $tempID]);
CRM/Core/Form.php:2270:      CRM_Core_Resources::singleton()->addVars('coreForm', ['contact_id' => (int) $userID]);
CRM/Contribute/Form/AbstractEditPayment.php:254:    CRM_Core_Resources::singleton()->addVars('coreForm', ['contact_id' => (int) $this->_contactID]);

````