### PR TITLE
Handle zero amount payment

### DIFF
--- a/eWAYRecurring.php
+++ b/eWAYRecurring.php
@@ -426,6 +426,7 @@ function validateEwayContribution($paymentProcessor, $invoiceID) {
       'return' => [
         'contribution_page_id',
         'contribution_recur_id',
+        'total_amount',
         'is_test',
       ],
       'is_test' => ($paymentProcessor->_mode == 'test') ? 1 : 0,
@@ -436,11 +437,12 @@ function validateEwayContribution($paymentProcessor, $invoiceID) {
       require_once extensionPath('vendor/autoload.php');
 
       $contribution = $contribution['values'][0];
-      $eWayAccessCode = CRM_Utils_Request::retrieve('AccessCode', 'String', $form, FALSE, "");
-      $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $form, FALSE, "");
+      if ($contribution['total_amount'] != '0.00') {
+        $eWayAccessCode = CRM_Utils_Request::retrieve('AccessCode', 'String', $form, FALSE, "");
+        $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String', $form, FALSE, "");
 
-      $paymentProcessor->validateContribution($eWayAccessCode, $contribution, $qfKey, $paymentProcessor->getPaymentProcessor());
-
+        $paymentProcessor->validateContribution($eWayAccessCode, $contribution, $qfKey, $paymentProcessor->getPaymentProcessor());
+      }
       return [
         'contribution' => $contribution,
       ];


### PR DESCRIPTION
Problem - $0 membership fee payment returns an error on submission -

To replicate -

- Create a membership type with Fee = $0.
- Add it on the contribution page - enable eway processor on it.
- Submit the page online.
- Error: Invalid Payment Amount

![image](https://user-images.githubusercontent.com/5929648/131643217-25b06468-ba4f-4ee7-ad64-328a5763f1ef.png)

- The contribution is set to `Failed`.

doPayment() is called even if total amount is 0. I see other processor eg Stripe have handled 0 amount payment in this function. But it seems missing in this ext?

Wth this PR - the payment is completed correctly.

