### PR TITLE
Fix failed recur payments to have correct amount

### DIFF
--- a/eWAYRecurring.process.inc
+++ b/eWAYRecurring.process.inc
@@ -129,7 +129,7 @@ function process_recurring_payments($payment_processor, $paymentObject) {
       // Civi::log()->debug("Creating contribution record\n");
       $new_contribution_record['contact_id'] = $contribution->contact_id;
       $new_contribution_record['receive_date'] = CRM_Utils_Date::isoToMysql(date('Y-m-d H:i:s'));
-      $new_contribution_record['total_amount'] = ($contribution->amount - $mainContributions['tax_amount']);
+      $new_contribution_record['total_amount'] = $contribution->amount;
       $new_contribution_record['contribution_recur_id'] = $contribution->id;
       $new_contribution_record['payment_instrument_id'] = $contribution->payment_instrument_id;
       $new_contribution_record['address_id'] = $billing_address['id'];


### PR DESCRIPTION
Failed recur payments have incorrect amount set on the contribution. To replicate, 

- Create a payment of $220 with $20 as the tax amount.
- When the automatic recur payment is processed and failed, the new contribution is created with Total amount = $200 (instead of $220).

There are no issues with Completed payment since it calls completetransaction API to update the status. This action does not update the total amount on the contribution.

With Failed - "create" API action is called which incorrectly updates the amount value excluding the tax amount. 

I'm not sure why this line was added. I think the contribution amount should always be same as the original amount? Thoughts?