### PR TITLE
Fixed notice error for permission defination

### DIFF
--- a/eWAYRecurring.php
+++ b/eWAYRecurring.php
@@ -320,6 +320,10 @@ function ewayrecurring_civicrm_coreResourceList(&$list, $region) {
  * @param $permissions permissions list to add to
  */
 function ewayrecurring_civicrm_permission(&$permissions) {
-  $permissions['view payment tokens'] = E::ts('CiviContribute: view payment tokens');
-  $permissions['edit payment tokens'] = E::ts('CiviContribute: edit payment tokens');
+  $permissions['view payment tokens'] = [
+    'label' => E::ts('CiviContribute: view payment tokens'),
+  ];
+  $permissions['edit payment tokens'] = [
+    'label' => E::ts('CiviContribute: edit payment tokens'),
+  ];
 }


### PR DESCRIPTION
https://civicrm.stackexchange.com/questions/47931/warning-after-upgrade-to-5-72-1-wordpress-re-deprecation-permission-view-paymen?noredirect=1#comment57662_47931