### PR TITLE
CIVIEWAY-281 and CIVIEWAY-282 - Fix backend actions not loading EWAY tokens due to missing Contact ID

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -15,10 +15,10 @@
     <email>support@agileware.com.au</email>
   </maintainer>
   <develStage>stable</develStage>
-  <releaseDate>2025-02-14</releaseDate>
-  <version>2.7.1</version>
+  <releaseDate>2025-07-23</releaseDate>
+  <version>2.7.2</version>
   <compatibility>
-    <ver>5.70</ver>
+    <ver>6.4.0</ver>
   </compatibility>
   <comments/>
   <civix>


### PR DESCRIPTION
- CIVIEWAY-281 - Backend action, New Payment for an existing Contribution fails to load stored credit card details because Contact ID is not set;
- CIVIEWAY-282 - Update Billing Info for a Recurring Contribution fails to load stored credit card details because Contact ID is not set