### PR TITLE
Add composer.json info and fix PHP type hint for unserialize

### DIFF
--- a/CRM/Core/Payment/eWAYRecurring.php
+++ b/CRM/Core/Payment/eWAYRecurring.php
@@ -140,7 +140,6 @@ class CRM_Core_Payment_eWAYRecurring extends CRM_Core_Payment {
         if (!$contact_id && $contribution_id = CRM_Utils_Request::retrieve('id', 'Int')) {
           $contact_id = civicrm_api3('Contribution', 'getvalue', ['id' => $contribution_id, 'return' => 'contact_id']);
         }
-      }
 
         if ($contact_id) {
           $jsSetting .= "CRM.eway.contact_id = {$contact_id};\n";

--- a/CRM/Core/Payment/eWAYRecurring.php
+++ b/CRM/Core/Payment/eWAYRecurring.php
@@ -140,6 +140,7 @@ class CRM_Core_Payment_eWAYRecurring extends CRM_Core_Payment {
         if (!$contact_id && $contribution_id = CRM_Utils_Request::retrieve('id', 'Int')) {
           $contact_id = civicrm_api3('Contribution', 'getvalue', ['id' => $contribution_id, 'return' => 'contact_id']);
         }
+      }
 
         if ($contact_id) {
           $jsSetting .= "CRM.eway.contact_id = {$contact_id};\n";

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+  "name": "agileware/au.com.agileware.ewayrecurring",
+  "type": "civicrm-ext",
+  "description": "CiviCRM Extension to support Integration with Eway Payment Processing",
   "require": {
     "eway/eway-rapid-php": "^2.0"
   }

--- a/eWAYRecurring.php
+++ b/eWAYRecurring.php
@@ -223,7 +223,7 @@ function ewayrecurring_civicrm_preProcess($formName, &$form) {
     case 'CRM_Event_Form_Registration_Confirm':
       $qfKey = $form->get('qfKey');
       $eWAYResponse = $qfKey ? unserialize(CRM_Core_Session::singleton()
-        ->get('eWAYResponse', $qfKey)) : FALSE;
+        ->get('eWAYResponse', $qfKey) ?? '') : FALSE;
       $paymentProcessor = $form->getVar('_paymentProcessor') ?? NULL;
       if (!empty($eWAYResponse->AccessCode) && ($paymentProcessor['object'] instanceof CRM_Core_Payment_eWAYRecurring)) {
         $transaction = CRM_eWAYRecurring_Utils::validateEwayAccessCode($eWAYResponse->AccessCode, $paymentProcessor);


### PR DESCRIPTION
Like many, we use `composer` to manage our package/extension installations. This PR adds the relevant info to `composer.json` to support CiviCRM extension install/management via `composer`.

The other thing this PR does is safeguard against a possible error for PHP 8+ deployments: `unserialize` doesn't like being passed `NULL` when it expects a string. So we use null coalesce to safeguard against `CRM_Core_Session::singleton()->get('eWAYResponse', $qfKey)` potentially returning a `NULL` value.
